### PR TITLE
Check if agent is installed before installing

### DIFF
--- a/src/pod.js
+++ b/src/pod.js
@@ -10,7 +10,18 @@ export class PodDisruptor {
         this.selector = options.selector || {}
         this.namespace = options.namespace || 'default'
         this.picker = options.picker || RANDOM_PICKER
-        this. pod =  this._selectPod()
+        this.pod =  this._selectPod()
+        this._addChaosAgent()
+    }
+
+    _addChaosAgent() {
+        const pod = this.client.pods.get(this.pod, this.namespace)
+        for (const c of pod.spec.ephemeral_containers) {
+            if (c.name == "k6-chaos" ) {
+                return
+            }
+        }
+
         this.client.pods.addEphemeralContainer(
             this.pod,
             this.namespace,


### PR DESCRIPTION
In some cases it is convenient to run multiples tests against the same target. As the ephemeral containers cannot be removed from a pod after a test, it is possible for the k6-chaos agent to be already installed in a target pod. This change set add a validation to avoid an error when trying to install it again.

Signed-off-by: Pablo Chacin <pablochacin@gmail.com>