### PR TITLE
Wait for k6-agent container to be ready

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Methods:
         - selector: labels for selecting target pod(s). An empty selector matches all pods
         - picker: strategy used for picking pod(s) to disrupt from potential targets.
           Presenlty the only suppored value is 'ramdom' (one random pod)
+        - wait: timeout (as a duration) for the disruptor to be initilized (defaults to '10s')
 
 `kill`: kill pod
 

--- a/src/pod.js
+++ b/src/pod.js
@@ -7,6 +7,7 @@ export class PodDisruptor {
     constructor(client, options) {
         this.client = client
         this.options = options
+        this.wait = options.wait || "30s"
         this.selector = options.selector || {}
         this.namespace = options.namespace || 'default'
         this.picker = options.picker || RANDOM_PICKER
@@ -30,9 +31,9 @@ export class PodDisruptor {
                 image: "grafana/k6-chaos",
                 pull_policy: "IfNotPresent",
                 capabilities: ["NET_ADMIN","NET_RAW"],
+                wait: this.wait
             }   
         )
-        sleep(10)  // give time for the container to start
     }
 
     _selectPod() {


### PR DESCRIPTION
Add option to the Pod disruptor for waiting until the k6-chaos agent is ready

Signed-off-by: Pablo Chacin <pablochacin@gmail.com>