### PR TITLE
Add option for excluding paths from disruption

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Methods:
           - target: port on which the requests will be intercepted (defaults is 80)
           - port: port the transparent proxy will use to listen for requests (default is 8080)
           - interface: interface on which the traffic will be intercepted (default is eth0)
+          - exclude: list of urls to be excluded from disruption (e.g. /health)
 
 ## Examples
 

--- a/src/pod.js
+++ b/src/pod.js
@@ -72,7 +72,8 @@ export class PodDisruptor {
 	    const port = options.port || 8080
         const error_code = options.error_code || 0
         const error_rate = options.error_rate || 0.0
-        const command = [
+        const exclude = options.exclude || []
+        let command = [
             "k6-chaos-agent",
             "http",
             "-a", delay,
@@ -83,11 +84,14 @@ export class PodDisruptor {
             "-p", port,
             "-t", target
         ]
+        exclude.forEach(e => {
+            command = command.concat("-x", e)
+        })
         this.client.pods.exec({
             pod: this.pod,
             namespace: this.namespace,
             container: "k6-chaos",
-	    command: command
+            command: command
         })
         return this.name
     }


### PR DESCRIPTION
Disrupting http request may cause the readiness/liveness probes of the target pod(s) to fail and force their restart. In some cases, this is not desirable. This change set adds the option for excluding paths from the disruption.

Signed-off-by: Pablo Chacin <pablochacin@gmail.com>