### PR TITLE
Make httpdisrupt defaults safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,14 +124,14 @@ Methods:
 
       Parameters:
         options: controls the attack
-          - delay: average delay in requests (in milliseconds)
-          - variation: variation in the delay (in milliseconds)
-          - error_rate: rate of requests that will return an error
+          - delay: average delay in requests (in milliseconds. Default is 0ms)
+          - variation: variation in the delay (in milliseconds. default is 0ms)
+          - error_rate: rate of requests that will return an error (float in the range 0.0 to 1.0. Default is 0.0)
           - error_code: error code to return
-          - duration: duration of the disruption
-          - target: port on which the requests will be intercepted (defaults to 80)
-          - port: port the transparent proxy will use to listen for requests (defaults to 8080)
-          - interface: interface on thich the traffic will be intercepted (defaults to eth0)
+          - duration: duration of the disruption (default is 30s)
+          - target: port on which the requests will be intercepted (defaults is 80)
+          - port: port the transparent proxy will use to listen for requests (default is 8080)
+          - interface: interface on which the traffic will be intercepted (default is eth0)
 
 ## Examples
 

--- a/agent/cmd/http.go
+++ b/agent/cmd/http.go
@@ -195,11 +195,13 @@ func (p proxy)Start() error {
 			body = originServerResponse.Body
 		}
 
-		delay := int(p.delay)
-		if p.variation > 0 {
-		   delay = delay + int(p.variation) - 2 *rand.Intn(int(p.variation))
+		if p.delay > 0 {
+			delay := int(p.delay)
+			if p.variation > 0 {
+				delay = delay + int(p.variation) - 2 *rand.Intn(int(p.variation))
+			}
+			time.Sleep(time.Duration(delay) * time.Millisecond)
 		}
-		time.Sleep(time.Duration(delay) * time.Millisecond)
 
         // return response to the client
 		// TODO: return headers

--- a/examples/disrupt-http.js
+++ b/examples/disrupt-http.js
@@ -47,7 +47,7 @@ export function disrupt(data) {
 
   podDisruptor.disruptHttp(
     {
-      delay: 100,
+      delay: 20,
       duration: "30s",
       error_code: 500,
       error_rate: 0.1

--- a/src/pod.js
+++ b/src/pod.js
@@ -66,7 +66,7 @@ export class PodDisruptor {
 
     disruptHttp(options){
         const duration = options.duration || '30s'
-        const delay = options.delay || 100
+        const delay = options.delay || 0
         const variation = options.variation || 0
 	    const target = options.target || 80
 	    const port = options.port || 8080


### PR DESCRIPTION
Make defaults for http disrupt safe (that is, have no effect)

Signed-off-by: Pablo Chacin <pablochacin@gmail.com>
